### PR TITLE
Add missing crypto module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const crypto = require('crypto')
 const app = express()
 const port = 8080
 


### PR DESCRIPTION
I got the following error:
```
/home/malte/MySpotBackup/index.js:21
    const digest = await crypto.subtle.digest('SHA-256', data);
                   ^

ReferenceError: crypto is not defined
    at generateCodeChallenge (/home/malte/MySpotBackup/index.js:21:20)
    at /home/malte/MySpotBackup/index.js:38:31
    at Layer.handle [as handle_request] (/home/malte/MySpotBackup/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/malte/MySpotBackup/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/home/malte/MySpotBackup/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/home/malte/MySpotBackup/node_modules/express/lib/router/layer.js:95:5)
    at /home/malte/MySpotBackup/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/home/malte/MySpotBackup/node_modules/express/lib/router/index.js:346:12)
    at next (/home/malte/MySpotBackup/node_modules/express/lib/router/index.js:280:10)
    at SendStream.error (/home/malte/MySpotBackup/node_modules/serve-static/index.js:121:7)

Node.js v18.19.1
```

I was able to make to it run adding that one line included in this pull request.